### PR TITLE
using Commmand.Traverse()

### DIFF
--- a/action.go
+++ b/action.go
@@ -17,7 +17,7 @@ type CompletionCallback func(args []string) Action
 // replaces value if a callback function is set
 func (a Action) finalize(uid string) Action {
 	if a.Callback != nil {
-		a.Value = ActionExecute(fmt.Sprintf("${os_args[1]} _zsh_completion '%v' ${os_args:1}", uid)).Value
+		a.Value = ActionExecute(fmt.Sprintf(`${os_args[1]} _zsh_completion '%v' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"}`, uid)).Value
 	}
 	return a
 }

--- a/action_test.go
+++ b/action_test.go
@@ -9,7 +9,7 @@ func TestActionCallback(t *testing.T) {
 		return ActionMessage("ActionCallback test")
 	}).finalize("someId")
 
-	if a.Value != ` eval \$(${os_args[1]} _zsh_completion 'someId' ${os_args:1})` {
+	if a.Value != ` eval \$(${os_args[1]} _zsh_completion 'someId' ${${os_args:1:gs/\"/\\\"}:gs/\'/\\\"})` {
 		t.Error(highlight(a.Value))
 	}
 }

--- a/example/cmd/root.go
+++ b/example/cmd/root.go
@@ -19,7 +19,7 @@ func init() {
 	rootCmd.PersistentFlags().StringP("persistentFlag", "p", "", "Help message for persistentFlag")
 	rootCmd.Flag("persistentFlag").NoOptDefVal = "defaultValue" // no argument required
 
-	rootCmd.Flags().StringArrayP("array", "a", []string{}, "mulitflag")
+	rootCmd.Flags().StringArrayP("array", "a", []string{}, "multiflag")
 
 	zsh.Gen(rootCmd).FlagCompletion(zsh.ActionMap{
 		"toggle": zsh.ActionBool(),

--- a/uid.go
+++ b/uid.go
@@ -39,7 +39,7 @@ func uidPositional(cmd *cobra.Command, position int) string {
 	return fmt.Sprintf("%v#%v", uidCommand(cmd), position)
 }
 
-func parse(uid string) []string {
+func splitUid(uid string) []string {
 	var splitted []string
 	if splitted = strings.Split(uid[1:], "#"); len(splitted) == 0 { // TODO check for empty uid string
 		return nil

--- a/zsh_test.go
+++ b/zsh_test.go
@@ -86,3 +86,36 @@ func TestSubcommandsSnippet(t *testing.T) {
 
 	t.Log(completions.actions)
 }
+
+func TestTraverse(t *testing.T) {
+	root := &cobra.Command{
+		Use: "test",
+	}
+	sub1 := &cobra.Command{
+		Use: "sub1",
+	}
+	sub2 := &cobra.Command{
+		Use: "sub2",
+	}
+
+	sub2.Flags()
+
+	root.AddCommand(sub1)
+	sub1.AddCommand(sub2)
+
+	root.PersistentFlags().String("license", "", "name of license for the project")
+	sub2.PersistentFlags().StringP("author", "a", "YOUR NAME", "author name for copyright attribution")
+
+	args := []string{"--license", "MIT", "sub1", "sub2", "positionalARG", "--author", "bob"}
+	targetArgs := traverse(sub1, args)
+
+	if len(targetArgs) != 1 || targetArgs[0] != "positionalARG" {
+		t.Error("traverse should return positionalARG")
+	}
+	if sub2.Flag("license").Value.String() != "MIT" {
+		t.Error("flag license should be MIT")
+	}
+	if sub2.Flag("author").Value.String() != "bob" {
+		t.Error("flag author should be bob")
+	}
+}


### PR DESCRIPTION
fixed `'` and `"` escaping for callback arguments