### PR TITLE
disabled flag parsing for _zsh_completion

### DIFF
--- a/zsh.go
+++ b/zsh.go
@@ -192,6 +192,7 @@ func addCompletionCommand(cmd *cobra.Command) {
 		FParseErrWhitelist: cobra.FParseErrWhitelist{
 			UnknownFlags: true,
 		},
+		DisableFlagParsing: true,
 	})
 }
 


### PR DESCRIPTION
persistent flags on root command without value caused a parse error on
callback