### PR TITLE
flag uid is now generated for the command it belongs to

### DIFF
--- a/uid.go
+++ b/uid.go
@@ -29,9 +29,16 @@ func uidCommand(cmd *cobra.Command) string {
 }
 
 func uidFlag(cmd *cobra.Command, flag *pflag.Flag) string {
+    c := cmd
+    for c.HasParent() {
+      if c.LocalFlags().Lookup(flag.Name) != nil {
+        break
+      }
+      c = c.Parent()
+    }
 	// TODO ensure flag acually belongs to command (force error)
-	// TODO handel unknown flag nil error
-	return fmt.Sprintf("%v##%v", uidCommand(cmd), flag.Name)
+	// TODO handle unknown flag error
+	return fmt.Sprintf("%v##%v", uidCommand(c), flag.Name)
 }
 
 func uidPositional(cmd *cobra.Command, position int) string {


### PR DESCRIPTION
- needed for persistent flag being completed on subcommands
- probably will still have issues since Command.Traverse() will target
  the subcommand if the flag is completed there (callback will be
  invoked with wrong arguments)